### PR TITLE
Add Schengen calendar heatmap

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,16 @@
 import { Button } from "@/components/ui/button"
 import { SchengenFileProcessor, type ProcessingResult } from "@/lib/schengen/processor"
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react"
+import { SchengenCalendar } from "@/components/SchengenCalendar"
+import { sampleDaysSet, sampleStats } from "@/fixtures/sampleData"
 import { Input } from "./components/ui/input";
 
 function App() {
   const [data, setData] = useState<ProcessingResult | null>(null);
   const [error, setError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const [stats] = useState(sampleStats)
+  const [daysSet] = useState(sampleDaysSet)
 
 
   const handleFile = useCallback(async (file: File) => {
@@ -39,7 +43,7 @@ function App() {
   }
 
   return (
-    <div className="flex min-h-svh flex-col items-center justify-center">
+    <div className="flex min-h-svh flex-col items-center justify-center gap-4 p-4">
       <Button onClick={handleUploadClick}>Click me</Button>
       <Input
         ref={fileInputRef}
@@ -51,11 +55,13 @@ function App() {
       {error && <p className="text-red-600">{error}</p>}
 
       {data && (
-        <div className="mt-4 space-y-1">
+        <div className="space-y-1">
           <p>Days used: {data.stats.used}</p>
           <p>Days left: {data.stats.left}</p>
         </div>
       )}
+
+      <SchengenCalendar stats={stats} daysSet={daysSet} />
     </div>
   )
 }

--- a/src/components/SchengenCalendar.tsx
+++ b/src/components/SchengenCalendar.tsx
@@ -1,0 +1,78 @@
+import { useMemo, useState } from "react"
+import { cn } from "@/lib/utils"
+import { sampleDaysSet, sampleStats, type Stats } from "@/fixtures/sampleData"
+
+export interface SchengenCalendarProps {
+  stats?: Stats
+  daysSet?: Map<number, { name: string; emoji: string }>
+}
+
+interface DayInfo {
+  date: Date
+  inSchengen: boolean
+}
+
+export function SchengenCalendar({
+  stats: initialStats = sampleStats,
+  daysSet: initialDays = sampleDaysSet,
+}: SchengenCalendarProps) {
+  const [stats] = useState(initialStats)
+  const [days] = useState(initialDays)
+
+  const dayList: DayInfo[] = useMemo(() => {
+    const arr: DayInfo[] = []
+    for (let i = 0; i < 180; i++) {
+      const ms = stats.windowStart + i * 86_400_000
+      const date = new Date(ms)
+      arr.push({ date, inSchengen: days.has(ms) })
+    }
+    return arr
+  }, [stats.windowStart, days])
+
+  const weeks = useMemo(() => {
+    const w: DayInfo[][] = []
+    for (let i = 0; i < dayList.length; i += 7) {
+      w.push(dayList.slice(i, i + 7))
+    }
+    return w
+  }, [dayList])
+
+  const monthLabels = useMemo(() => {
+    const fmt = new Intl.DateTimeFormat("en", { month: "short" })
+    return weeks.map((week, idx) => {
+      const month = fmt.format(week[0].date)
+      const prev = weeks[idx - 1]?.[0].date
+      return !prev || prev.getUTCMonth() !== week[0].date.getUTCMonth()
+        ? month
+        : ""
+    })
+  }, [weeks])
+
+  return (
+    <div className="overflow-x-auto">
+      <div className="flex gap-1 text-xs mb-1">
+        {monthLabels.map((label, idx) => (
+          <div key={idx} className="h-4 w-3 flex items-center justify-center">
+            {label}
+          </div>
+        ))}
+      </div>
+      <div className="flex gap-1">
+        {weeks.map((week, wIdx) => (
+          <div key={wIdx} className="flex flex-col gap-1">
+            {week.map((day, dIdx) => (
+              <div
+                key={dIdx}
+                title={day.date.toISOString().split("T")[0]}
+                className={cn(
+                  "h-3 w-3 rounded-sm",
+                  day.inSchengen ? "bg-primary" : "bg-muted"
+                )}
+              />
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- show a calendar style map of Schengen days
- sample data lives in fixtures and is rendered with a new `SchengenCalendar` component
- wire the calendar into `App`

## Testing
- `pnpm lint` *(fails: cannot find plugin "react-x")*
- `pnpm run build`

------
https://chatgpt.com/codex/tasks/task_e_68433d2d669c8320a5b295af966e1c27