### PR TITLE
Fix ESLint plugin config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,10 +14,16 @@ export default tseslint.config(
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
+      parserOptions: {
+        project: ['./tsconfig.app.json', './tsconfig.node.json'],
+        tsconfigRootDir: new URL('.', import.meta.url).pathname,
+      },
     },
     plugins: {
       'react-hooks': reactHooks,
       'react-refresh': reactRefresh,
+      'react-x': reactX,
+      'react-dom': reactDom,
     },
     rules: {
       ...reactHooks.configs.recommended.rules,

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
     "merge-geo": "node scripts/merge-geo.cjs"
   },
   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.3",
+    "@tailwindcss/vite": "^4.1.8",
     "@turf/boolean-point-in-polygon": "^7.2.0",
     "@turf/helpers": "^7.2.0",
     "@turf/projection": "^7.2.0",
-    "@radix-ui/react-slot": "^1.2.3",
-    "@tailwindcss/vite": "^4.1.8",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.513.0",
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
+    "@types/geojson": "^7946.0.16",
     "@types/node": "^22.15.30",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@eslint/js':
         specifier: ^9.25.0
         version: 9.28.0
+      '@types/geojson':
+        specifier: ^7946.0.16
+        version: 7946.0.16
       '@types/node':
         specifier: ^22.15.30
         version: 22.15.30

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,14 +24,18 @@ function App() {
       const result = await processor.processFile(file);
       setData(result);
 
-    } catch (err: any) {
-      setError(err.message || 'Failed to read file');
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError('Failed to read file');
+      }
     }
   }, []);
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
-    if (file) handleFile(file)
+    if (file) void handleFile(file)
   }
 
   const handleUploadClick = () => {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -56,4 +56,4 @@ function Button({
   )
 }
 
-export { Button, buttonVariants }
+export { Button }

--- a/src/lib/schengen/processor.tsx
+++ b/src/lib/schengen/processor.tsx
@@ -1,4 +1,4 @@
-import { timelineToVisit, collectSchengenDays, windowStats, type Visit } from './calculator';
+import { timelineToVisit, collectSchengenDays, windowStats, type Visit, type TimelineEntry } from './calculator';
 
 export interface ProcessingResult {
   stats: {
@@ -6,7 +6,7 @@ export interface ProcessingResult {
     left: number;
     windowStart: number;
   };
-  daysSet: Map<number, any>;
+  daysSet: Map<number, Record<string, unknown>>;
   visits: Visit[];
 }
 
@@ -14,7 +14,7 @@ export class SchengenFileProcessor {
   public async processFile(file: File): Promise<ProcessingResult> {
     try {
       const text = await file.text();
-      const jsonArray = JSON.parse(text);
+      const jsonArray = JSON.parse(text) as TimelineEntry[];
 
       // Process visits
       const visits = Array.from(timelineToVisit(jsonArray));
@@ -39,7 +39,7 @@ export class SchengenFileProcessor {
   public async validateFile(file: File): Promise<boolean> {
     try {
       const text = await file.text();
-      const jsonArray = JSON.parse(text);
+      const jsonArray = JSON.parse(text) as unknown;
       return Array.isArray(jsonArray);
     } catch {
       return false;
@@ -54,8 +54,10 @@ export class SchengenFileProcessor {
     const daysSet = await collectSchengenDays(visits);
     const countries = new Set<string>();
 
-    for (const [_, country] of daysSet) {
-      countries.add(country.name);
+    for (const country of daysSet.values()) {
+      if (typeof country.name === 'string') {
+        countries.add(country.name);
+      }
     }
 
     return {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,7 +3,10 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 
-createRoot(document.getElementById('root')!).render(
+const rootElement = document.getElementById('root')
+if (!rootElement) throw new Error('Root element not found')
+
+createRoot(rootElement).render(
   <StrictMode>
     <App />
   </StrictMode>,


### PR DESCRIPTION
## Summary
- include `react-x` and `react-dom` plugins in ESLint config
- configure parser options for TypeScript
- address lint errors in source files
- install `@types/geojson`

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68433a15a8588320a4a9445627f74596