### PR TITLE
Display flag emoji in calendar days

### DIFF
--- a/src/components/SchengenCalendar.tsx
+++ b/src/components/SchengenCalendar.tsx
@@ -10,7 +10,7 @@ export interface SchengenCalendarProps {
 
 interface DayInfo {
   date: Date
-  inSchengen: boolean
+  country?: { name: string; emoji: string }
 }
 
 export function SchengenCalendar({
@@ -30,7 +30,7 @@ export function SchengenCalendar({
     for (let i = 0; i < 180; i++) {
       const ms = startMs + i * 86_400_000
       const date = new Date(ms)
-      arr.push({ date, inSchengen: days.has(ms) })
+      arr.push({ date, country: days.get(ms) })
     }
     return arr
   }, [startMs, days])
@@ -69,12 +69,22 @@ export function SchengenCalendar({
             {week.map((day, dIdx) => (
               <div
                 key={dIdx}
-                title={day.date.toISOString().split("T")[0]}
+                title={
+                  day.country
+                    ? `${day.date.toISOString().split("T")[0]} - ${day.country.name}`
+                    : day.date.toISOString().split("T")[0]
+                }
                 className={cn(
-                  "h-3 w-3 rounded-sm",
-                  day.inSchengen ? "bg-primary" : "bg-muted"
+                  "h-3 w-3 rounded-sm flex items-center justify-center overflow-hidden",
+                  !day.country && "bg-muted"
                 )}
-              />
+              >
+                {day.country && (
+                  <span className="mask-circle text-[10px] leading-none">
+                    {day.country.emoji}
+                  </span>
+                )}
+              </div>
             ))}
           </div>
         ))}

--- a/src/index.css
+++ b/src/index.css
@@ -118,3 +118,10 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer utilities {
+  .mask-circle {
+    -webkit-mask-image: radial-gradient(circle, black 99%, transparent 100%);
+    mask-image: radial-gradient(circle, black 99%, transparent 100%);
+  }
+}

--- a/src/lib/schengen/calculator.tsx
+++ b/src/lib/schengen/calculator.tsx
@@ -4,9 +4,13 @@ import { msToUTCmidnight } from './dateUtils'
 import { parseLatLon } from "./locationUtils";
 import type { FeatureCollection, Feature, Polygon, MultiPolygon } from 'geojson'
 
+export interface CountryInfo {
+    name: string
+    emoji: string
+}
 
-type SchengenFeature = Feature<Polygon | MultiPolygon, Record<string, unknown>>
-type SchengenCollection = FeatureCollection<Polygon | MultiPolygon, Record<string, unknown>>
+type SchengenFeature = Feature<Polygon | MultiPolygon, CountryInfo>
+type SchengenCollection = FeatureCollection<Polygon | MultiPolygon, CountryInfo>
 
 let schengenCache: SchengenCollection | null = null
 
@@ -18,15 +22,15 @@ export async function loadSchengen(): Promise<SchengenCollection> {
     return schengenCache
 }
 
-export async function getSchengenCountry(lat: number, lon: number): Promise<Record<string, unknown> | null> {
+export async function getSchengenCountry(lat: number, lon: number): Promise<CountryInfo | null> {
     const geoJson = await loadSchengen()
     const pt = point([lon, lat])
     const country = geoJson.features.find((c: SchengenFeature) => booleanPointInPolygon(pt, c))
     return country ? country.properties : null
 }
 
-export async function collectSchengenDays(visits: Iterable<Visit>): Promise<Map<number, Record<string, unknown>>> {
-    const days = new Map<number, Record<string, unknown>>()
+export async function collectSchengenDays(visits: Iterable<Visit>): Promise<Map<number, CountryInfo>> {
+    const days = new Map<number, CountryInfo>()
     for (const v of visits) {
         const country = await getSchengenCountry(v.lat, v.lon)
         if (!country) continue

--- a/src/lib/schengen/processor.tsx
+++ b/src/lib/schengen/processor.tsx
@@ -1,4 +1,4 @@
-import { timelineToVisit, collectSchengenDays, windowStats, type Visit, type TimelineEntry } from './calculator';
+import { timelineToVisit, collectSchengenDays, windowStats, type Visit, type TimelineEntry, type CountryInfo } from './calculator';
 
 export interface ProcessingResult {
   stats: {
@@ -6,7 +6,7 @@ export interface ProcessingResult {
     left: number;
     windowStart: number;
   };
-  daysSet: Map<number, Record<string, unknown>>;
+  daysSet: Map<number, CountryInfo>;
   visits: Visit[];
 }
 


### PR DESCRIPTION
## Summary
- type country info with emoji and name
- show emoji flags for visited days in the calendar
- mask emoji so it stays within the circular day cell

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*
- `pnpm exec tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_6843494f31c08320accad5d799ffadc0