### PR TITLE
Make calendar horizontally scrollable on mobile

### DIFF
--- a/src/components/SchengenCalendar.tsx
+++ b/src/components/SchengenCalendar.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react"
 import { cn } from "@/lib/utils"
+import { ScrollArea } from "@/components/ui/scroll-area"
 import { sampleDaysSet, sampleStats, type Stats } from "@/fixtures/sampleData"
 import { msToUTCmidnight } from "@/lib/schengen/dateUtils"
 
@@ -47,23 +48,22 @@ export function SchengenCalendar({
     const fmt = new Intl.DateTimeFormat("en", { month: "short" })
     return weeks.map((week, idx) => {
       const month = fmt.format(week[0].date)
-      const prev = weeks[idx - 1]?.[0].date
-      return !prev || prev.getUTCMonth() !== week[0].date.getUTCMonth()
-        ? month
-        : ""
+      if (idx === 0) return month
+      const prev = weeks[idx - 1][0].date
+      return prev.getUTCMonth() !== week[0].date.getUTCMonth() ? month : ""
     })
   }, [weeks])
 
   return (
-    <div className="overflow-x-auto">
-      <div className="flex gap-1 text-xs mb-1">
+    <ScrollArea orientation="horizontal" className="max-w-full sm:overflow-visible">
+      <div className="flex gap-1 text-xs mb-1 w-fit">
         {monthLabels.map((label, idx) => (
           <div key={idx} className="h-5 w-5 flex items-center justify-center">
             {label}
           </div>
         ))}
       </div>
-      <div className="flex gap-1">
+      <div className="flex gap-1 w-fit">
         {weeks.map((week, wIdx) => (
           <div key={wIdx} className="flex flex-col gap-1">
             {week.map((day, dIdx) => (
@@ -89,6 +89,6 @@ export function SchengenCalendar({
           </div>
         ))}
       </div>
-    </div>
+    </ScrollArea>
   )
 }

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -3,11 +3,19 @@ import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
 
 import { cn } from "@/lib/utils"
 
+type Orientation = "vertical" | "horizontal" | "both"
+
+interface ScrollAreaProps
+  extends React.ComponentProps<typeof ScrollAreaPrimitive.Root> {
+  orientation?: Orientation
+}
+
 function ScrollArea({
   className,
   children,
+  orientation = "vertical",
   ...props
-}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+}: ScrollAreaProps) {
   return (
     <ScrollAreaPrimitive.Root
       data-slot="scroll-area"
@@ -20,7 +28,12 @@ function ScrollArea({
       >
         {children}
       </ScrollAreaPrimitive.Viewport>
-      <ScrollBar />
+      {(orientation === "vertical" || orientation === "both") && (
+        <ScrollBar orientation="vertical" />
+      )}
+      {(orientation === "horizontal" || orientation === "both") && (
+        <ScrollBar orientation="horizontal" />
+      )}
       <ScrollAreaPrimitive.Corner />
     </ScrollAreaPrimitive.Root>
   )
@@ -38,9 +51,9 @@ function ScrollBar({
       className={cn(
         "flex touch-none p-px transition-colors select-none",
         orientation === "vertical" &&
-          "h-full w-2.5 border-l border-l-transparent",
+          "h-full w-1 border-l border-l-transparent",
         orientation === "horizontal" &&
-          "h-2.5 flex-col border-t border-t-transparent",
+          "h-1 flex-col border-t border-t-transparent",
         className
       )}
       {...props}

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -51,9 +51,9 @@ function ScrollBar({
       className={cn(
         "flex touch-none p-px transition-colors select-none",
         orientation === "vertical" &&
-          "h-full w-1 border-l border-l-transparent",
+        "h-full w-2 border-l border-l-transparent",
         orientation === "horizontal" &&
-          "h-1 flex-col border-t border-t-transparent",
+        "h-2 flex-col border-t border-t-transparent",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- allow `<ScrollArea />` to specify orientation
- use `<ScrollArea orientation="horizontal" />` for `<SchengenCalendar />`
- slim down the horizontal scroll bar
- fix lint issue for month labels

## Testing
- `pnpm install`
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68435015d81c8320b1e0649b0f68ef17