### PR TITLE
Add scroll-driven story page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { useCallback, useRef, useState } from "react"
 import { SchengenCalendar } from "@/components/SchengenCalendar"
 import { sampleDaysSet, sampleStats } from "@/fixtures/sampleData"
 import { Input } from "./components/ui/input";
+import { Story } from "@/components/Story"
 
 function App() {
   const [data, setData] = useState<ProcessingResult | null>(null);
@@ -47,7 +48,8 @@ function App() {
   }
 
   return (
-    <div className="flex min-h-svh flex-col items-center justify-center gap-4 p-4">
+    <div className="flex min-h-svh flex-col gap-4 p-4">
+      <Story />
       <Button onClick={handleUploadClick}>Click me</Button>
       <Input
         ref={fileInputRef}

--- a/src/components/SchengenCalendar.tsx
+++ b/src/components/SchengenCalendar.tsx
@@ -47,8 +47,10 @@ export function SchengenCalendar({
     const fmt = new Intl.DateTimeFormat("en", { month: "short" })
     return weeks.map((week, idx) => {
       const month = fmt.format(week[0].date)
-      const prev = weeks[idx - 1]?.[0].date
-      return !prev || prev.getUTCMonth() !== week[0].date.getUTCMonth()
+      const prevWeek = weeks[idx - 1]
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      const prevDate = prevWeek ? prevWeek[0].date : undefined
+      return !prevDate || prevDate.getUTCMonth() !== week[0].date.getUTCMonth()
         ? month
         : ""
     })

--- a/src/components/Story.tsx
+++ b/src/components/Story.tsx
@@ -1,0 +1,37 @@
+import { ScrollArea } from "@/components/ui/scroll-area"
+
+const paragraphs = [
+  "Why I Built This Calculator (A Tragicomedy in 90 Days)",
+  "It all began at the Copenhagen border.",
+  "My Swedish wife had already glided through passport control, practically applauded through by the border guard. Scandinavian passport. Blue and gold. No queue, no fuss, just a smile and a \u201cV\u00E4lkommen hem.\u201d",
+  "I, on the other hand, was banished to the Brexit lane \u2014 a sad, snaking line of weary Brits clutching maroon passports like museum relics. When I finally reached the front, I handed over my passport with my best \u201csurely-we\u2019re-still-friends?\u201d grin.",
+  "The border officer did not smile back.",
+  "Instead, she began flipping through my passport like a blackjack dealer, lips moving silently as she counted. Then she did it again. And again. Her brow furrowed deeper with each pass, until I began to worry she was calculating my life expectancy, not my travel history.",
+  "After a long pause, she picked up the phone and spoke rapid Danish to someone who sounded very important and very unimpressed. I heard my name. I heard \u201cUnited Kingdom.\u201d I heard \u201cnon-resident overstayer?\u201d followed by the unmistakable European sigh of bureaucratic doom.",
+  "My wife was already picking up her luggage.",
+  "Eventually, with a dramatic sigh and one final scowl, she handed back my passport and said:",
+  "\u201cYou\u2019ve overstayed. But\u2026 we\u2019ll grant you 24 more hours.\u201d",
+  "One more day in the EU. Like some kind of Brexit Cinderella, I had until midnight (the next day) before I turned back into a pumpkin and was catapulted across the North Sea.",
+  "That\u2019s when I knew: there had to be a better way.",
+  "So I built this calculator.",
+  "It reads your Google Timeline export \u2014 yes, the one quietly tracking everywhere you\u2019ve been since 2012 \u2014 and calculates exactly how many Schengen days you\u2019ve used and how many you\u2019ve got left. No guessing. No calendar spreadsheets. No awkward standoffs in Copenhagen while your wife is halfway to the rental car.",
+]
+
+export function Story() {
+  return (
+    <ScrollArea className="h-svh w-full snap-y snap-mandatory overflow-y-scroll">
+      <div>
+        {paragraphs.map((p, i) => (
+          <section
+            key={i}
+            className="snap-center h-svh flex items-center justify-center px-6"
+          >
+            <p className="text-balance text-center font-serif text-2xl md:text-4xl">
+              {p}
+            </p>
+          </section>
+        ))}
+      </div>
+    </ScrollArea>
+  )
+}


### PR DESCRIPTION
## Summary
- create a `Story` component that shows each paragraph full-screen in a scroll area
- include the new story in the main `App`
- tweak month label logic to satisfy lint

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6843524e86208320a1223007f64d6cc1