### PR TITLE
Add flag toggle and wider calendar

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@radix-ui/react-scroll-area": "^1.2.9",
     "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-toggle": "^1.1.9",
     "@tailwindcss/vite": "^4.1.8",
     "@turf/boolean-point-in-polygon": "^7.2.0",
     "@turf/helpers": "^7.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.3(@types/react@19.1.6)(react@19.1.0)
+      '@radix-ui/react-toggle':
+        specifier: ^1.1.9
+        version: 1.1.9(@types/react-dom@19.1.6(@types/react@19.1.6))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@tailwindcss/vite':
         specifier: ^4.1.8
         version: 4.1.8(vite@6.3.5(@types/node@22.15.30)(jiti@2.4.2)(lightningcss@1.30.1))
@@ -529,8 +532,39 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-toggle@1.1.9':
+    resolution: {integrity: sha512-ZoFkBBz9zv9GWer7wIjvdRxmh2wyc2oKWw6C6CseWd6/yq1DK/l5lJ+wnsmFwJZbBYqr02mrf8A2q/CVCuM3ZA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-use-callback-ref@1.1.1':
     resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.2':
+    resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.2':
+    resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2006,8 +2040,34 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.6
 
+  '@radix-ui/react-toggle@1.1.9(@types/react-dom@19.1.6(@types/react@19.1.6))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.6))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.6)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.6
+      '@types/react-dom': 19.1.6(@types/react@19.1.6)
+
   '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.1.6)(react@19.1.0)':
     dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.6
+
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.1.6)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.1.6)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.6)(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.6
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.1.6)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.6)(react@19.1.0)
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.6

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,10 @@
 import { Button } from "@/components/ui/button"
+import { Toggle } from "@/components/ui/toggle"
 import { SchengenFileProcessor, type ProcessingResult } from "@/lib/schengen/processor"
 import { useCallback, useRef, useState } from "react"
 import { SchengenCalendar } from "@/components/SchengenCalendar"
 import { sampleDaysSet, sampleStats } from "@/fixtures/sampleData"
-import { Input } from "./components/ui/input";
+import { Input } from "./components/ui/input"
 import { Story } from "@/components/Story"
 
 function App() {
@@ -12,6 +13,7 @@ function App() {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [stats] = useState(sampleStats)
   const [daysSet] = useState(sampleDaysSet)
+  const [showEmoji, setShowEmoji] = useState(true)
 
 
   const handleFile = useCallback(async (file: File) => {
@@ -48,9 +50,11 @@ function App() {
   }
 
   return (
-    <div className="flex min-h-svh flex-col gap-4 p-4">
+    <div className="flex min-h-svh flex-col items-center gap-6 p-4">
       <Story />
-      <Button onClick={handleUploadClick}>Import location-history.json </Button>
+      <Button className="mt-10" onClick={handleUploadClick}>
+        Import location-history.json
+      </Button>
       <Input
         ref={fileInputRef}
         type="file"
@@ -58,6 +62,13 @@ function App() {
         onChange={onChange}
         className="hidden"
       />
+      <Toggle
+        pressed={showEmoji}
+        onPressedChange={setShowEmoji}
+        className="mx-auto"
+      >
+        Show flags
+      </Toggle>
       {error && <p className="text-red-600">{error}</p>}
 
       {data && (
@@ -67,7 +78,7 @@ function App() {
         </div>
       )}
 
-      <SchengenCalendar stats={stats} daysSet={daysSet} />
+      <SchengenCalendar stats={stats} daysSet={daysSet} showEmoji={showEmoji} />
     </div>
   )
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ function App() {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [stats] = useState(sampleStats)
   const [daysSet] = useState(sampleDaysSet)
-  const [showEmoji, setShowEmoji] = useState(true)
+  const [showEmoji, setShowEmoji] = useState(false)
 
 
   const handleFile = useCallback(async (file: File) => {
@@ -67,7 +67,7 @@ function App() {
         onPressedChange={setShowEmoji}
         className="mx-auto"
       >
-        Show flags
+        Show emoji
       </Toggle>
       {error && <p className="text-red-600">{error}</p>}
 

--- a/src/components/SchengenCalendar.tsx
+++ b/src/components/SchengenCalendar.tsx
@@ -6,6 +6,7 @@ import { msToUTCmidnight } from "@/lib/schengen/dateUtils"
 export interface SchengenCalendarProps {
   stats?: Stats
   daysSet?: Map<number, { name: string; emoji: string }>
+  showEmoji?: boolean
 }
 
 interface DayInfo {
@@ -16,6 +17,7 @@ interface DayInfo {
 export function SchengenCalendar({
   stats: initialStats = sampleStats,
   daysSet: initialDays = sampleDaysSet,
+  showEmoji = true,
 }: SchengenCalendarProps) {
   const [stats] = useState(initialStats)
   const [days] = useState(initialDays)
@@ -57,17 +59,17 @@ export function SchengenCalendar({
   }, [weeks])
 
   return (
-    <div className="overflow-x-auto">
-      <div className="flex gap-1 text-xs mb-1">
+    <div className="w-full max-w-6xl mx-auto">
+      <div className="flex gap-0.5 text-xs mb-1">
         {monthLabels.map((label, idx) => (
-          <div key={idx} className="h-5 w-5 flex items-center justify-center">
+          <div key={idx} className="flex-1 h-5 flex items-center justify-center">
             {label}
           </div>
         ))}
       </div>
-      <div className="flex gap-1">
+      <div className="flex gap-0.5">
         {weeks.map((week, wIdx) => (
-          <div key={wIdx} className="flex flex-col gap-1">
+          <div key={wIdx} className="flex flex-1 flex-col gap-0.5">
             {week.map((day, dIdx) => (
               <div
                 key={dIdx}
@@ -77,11 +79,12 @@ export function SchengenCalendar({
                     : day.date.toISOString().split("T")[0]
                 }
                 className={cn(
-                  "h-5 w-5 rounded-sm flex items-center justify-center overflow-hidden",
-                  !day.country && "bg-muted"
+                  "aspect-square w-full rounded-sm flex items-center justify-center overflow-hidden",
+                  !day.country && "bg-muted",
+                  day.country && !showEmoji && "bg-foreground"
                 )}
               >
-                {day.country && (
+                {day.country && showEmoji && (
                   <span className="mask-circle text-lg leading-none">
                     {day.country.emoji}
                   </span>

--- a/src/components/SchengenCalendar.tsx
+++ b/src/components/SchengenCalendar.tsx
@@ -67,9 +67,9 @@ export function SchengenCalendar({
           </div>
         ))}
       </div>
-      <div className="flex gap-0.5">
+      <div className="flex gap-2">
         {weeks.map((week, wIdx) => (
-          <div key={wIdx} className="flex flex-1 flex-col gap-0.5">
+          <div key={wIdx} className="flex flex-1 flex-col gap-2">
             {week.map((day, dIdx) => (
               <div
                 key={dIdx}
@@ -85,7 +85,7 @@ export function SchengenCalendar({
                 )}
               >
                 {day.country && showEmoji && (
-                  <span className="mask-circle text-lg leading-none">
+                  <span className="mask-circle text-2xl leading-none">
                     {day.country.emoji}
                   </span>
                 )}

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import * as React from "react"
+import * as TogglePrimitive from "@radix-ui/react-toggle"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const toggleVariants = cva(
+  "inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 gap-2",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline:
+          "border border-input bg-transparent hover:bg-accent hover:text-accent-foreground",
+      },
+      size: {
+        default: "h-10 px-3 min-w-10",
+        sm: "h-9 px-2.5 min-w-9",
+        lg: "h-11 px-5 min-w-11",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+const Toggle = React.forwardRef<
+  React.ComponentRef<typeof TogglePrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof TogglePrimitive.Root> &
+    VariantProps<typeof toggleVariants>
+>(({ className, variant, size, ...props }, ref) => (
+  <TogglePrimitive.Root
+    ref={ref}
+    className={cn(toggleVariants({ variant, size, className }))}
+    {...props}
+  />
+))
+
+Toggle.displayName = TogglePrimitive.Root.displayName
+
+export { Toggle, toggleVariants }

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import * as React from "react"
 import * as TogglePrimitive from "@radix-ui/react-toggle"
 import { cva, type VariantProps } from "class-variance-authority"
@@ -7,18 +5,18 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const toggleVariants = cva(
-  "inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 gap-2",
+  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium hover:bg-muted hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none transition-[color,box-shadow] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive whitespace-nowrap",
   {
     variants: {
       variant: {
         default: "bg-transparent",
         outline:
-          "border border-input bg-transparent hover:bg-accent hover:text-accent-foreground",
+          "border border-input bg-transparent shadow-xs hover:bg-accent hover:text-accent-foreground",
       },
       size: {
-        default: "h-10 px-3 min-w-10",
-        sm: "h-9 px-2.5 min-w-9",
-        lg: "h-11 px-5 min-w-11",
+        default: "h-9 px-2 min-w-9",
+        sm: "h-8 px-1.5 min-w-8",
+        lg: "h-10 px-2.5 min-w-10",
       },
     },
     defaultVariants: {
@@ -28,18 +26,20 @@ const toggleVariants = cva(
   }
 )
 
-const Toggle = React.forwardRef<
-  React.ComponentRef<typeof TogglePrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof TogglePrimitive.Root> &
-    VariantProps<typeof toggleVariants>
->(({ className, variant, size, ...props }, ref) => (
-  <TogglePrimitive.Root
-    ref={ref}
-    className={cn(toggleVariants({ variant, size, className }))}
-    {...props}
-  />
-))
-
-Toggle.displayName = TogglePrimitive.Root.displayName
+function Toggle({
+  className,
+  variant,
+  size,
+  ...props
+}: React.ComponentProps<typeof TogglePrimitive.Root> &
+  VariantProps<typeof toggleVariants>) {
+  return (
+    <TogglePrimitive.Root
+      data-slot="toggle"
+      className={cn(toggleVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
 
 export { Toggle, toggleVariants }


### PR DESCRIPTION
## Summary
- add shadcn Toggle component
- install `@radix-ui/react-toggle`
- show `Import location-history.json` button above a flag toggle
- allow hiding emojis on the calendar
- make calendar fill most of the width

## Testing
- `npx eslint .`
- `pnpm run build`

------
https://chatgpt.com/codex/tasks/task_e_684356aa247083208035f2dc37ca7b4f