### PR TITLE
Add fading days left display

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,9 +72,16 @@ function App() {
       {error && <p className="text-red-600">{error}</p>}
 
       {data && (
-        <div className="space-y-1">
-          <p>Days used: {data.stats.used}</p>
-          <p>Days left: {data.stats.left}</p>
+        <div className="animate-in fade-in space-y-2 text-center">
+          <p className="text-balance font-serif text-7xl font-semibold">
+            {data.stats.left > 0
+              ? `${String(data.stats.left)} days left`
+              : 'No days left'}
+          </p>
+          <p className="text-sm">Days used: {data.stats.used}</p>
+          {data.stats.left <= 0 && (
+            <p className="text-red-600 text-lg">You have overstayed!</p>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- show a large days-left indicator that fades in after processing
- warn when no days are left

## Testing
- `pnpm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68435b19c8a08320980429c8f78ff807