### PR TITLE
Fix calendar update from imports

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,8 +18,8 @@ function App() {
   const importButtonRef = useRef<HTMLButtonElement>(null)
   const hideSkip = useIsIntersecting(importButtonRef, { threshold: 0.5 })
 
-  const [stats] = useState(sampleStats)
-  const [daysSet] = useState(sampleDaysSet)
+  const stats = data?.stats ?? sampleStats
+  const daysSet = data?.daysSet ?? sampleDaysSet
 
   const handleFile = useCallback(async (file: File) => {
     try {

--- a/src/components/SchengenCalendar.tsx
+++ b/src/components/SchengenCalendar.tsx
@@ -15,11 +15,9 @@ interface DayInfo {
 }
 
 export function SchengenCalendar({
-  stats: initialStats = sampleStats,
-  daysSet: initialDays = sampleDaysSet,
+  stats = sampleStats,
+  daysSet = sampleDaysSet,
 }: SchengenCalendarProps) {
-  const [stats] = useState(initialStats)
-  const [days] = useState(initialDays)
   const [showEmoji, setShowEmoji] = useState(false)
 
   const startMs = useMemo(
@@ -32,10 +30,10 @@ export function SchengenCalendar({
     for (let i = 0; i < 180; i++) {
       const ms = startMs + i * 86_400_000
       const date = new Date(ms)
-      arr.push({ date, country: days.get(ms) })
+      arr.push({ date, country: daysSet.get(ms) })
     }
     return arr
-  }, [startMs, days])
+  }, [startMs, daysSet])
 
   const weeks = useMemo(() => {
     const w: DayInfo[][] = []


### PR DESCRIPTION
## Summary
- use imported stats/days to update calendar
- ensure `App` passes imported data to calendar

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68436c852b248320a17d6617c541ccbd